### PR TITLE
Issue with Page Refresh on Typing in Comment Text Box

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1094,6 +1094,11 @@ text-decoration: none;
           if (e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) {
             return;
           }
+          // Check if the current focus is on an input or textarea element
+          if (document.activeElement.tagName === "INPUT" || document.activeElement.tagName === "TEXTAREA") {
+            return;
+          }
+
 
           var view_all = await GM.getValue("view_all", true);
 


### PR DESCRIPTION
### Description
When I add a new comment (by clicking [Post New Comment]), the page automatically refreshes after entering characters in the text box. After some investigation, it seems that this issue is caused by the script. This bug needs to be fixed.

### Problematic Code
The current script sets up shortcut keys for navigation, but these shortcuts should not be triggered while typing in the text box. The code is as follows:

```javascript
document.addEventListener("keydown", async (e) => {
  // ignore key combinations
  if (e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) {
    return;
  }

  var view_all = await GM.getValue("view_all", true);

  if (view_all === true) {
    return;
  }

  if (e.code === "ArrowLeft" || e.code === "KeyA") {
    e.preventDefault();
    childNodes[0].click();
  }

  if (e.code === "ArrowRight" || e.code === "KeyD") {
    e.preventDefault();
    childNodes[childNodes.length - 1].click();
  }
});
```

### Suggested Fix
To prevent this behavior, you should add a check to see if the current focus is on an input or textarea element. If so, the shortcut keys should not be triggered. Add the following code:

```javascript
// Check if the current focus is on an input or textarea element
if (document.activeElement.tagName === "INPUT" || document.activeElement.tagName === "TEXTAREA") {
  return;
}
```